### PR TITLE
Update platformio.ini

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
           - olimex_esp32-gateway-f_dev
           - olimex_esp32-poe-iso
           - heltec_esp32-wifi-lora-v2
+          - wt32-eth01
         gui:
           - name: gui-v2
             repo: OpenEVSE/openevse-gui-v2

--- a/platformio.ini
+++ b/platformio.ini
@@ -319,3 +319,26 @@ build_flags =
   -D RAPI_PORT=Serial1
   -D RX1=25
   -D TX1=27
+
+[env:wt32-eth01]
+# For Wireless Tag
+board = wt32-eth01
+build_flags =
+  ${common.build_flags}
+  ${common.src_build_flags}
+  -D WIFI_LED=12
+  -D WIFI_LED_ON_STATE=HIGH
+  -D WIFI_BUTTON=4
+  -D WIFI_BUTTON_PRESSED_STATE=LOW
+ # -D DEBUG_PORT=Serial
+  -D RAPI_PORT=Serial2
+  -D ENABLE_WIRED_ETHERNET
+  -D RESET_ETH_PHY_ON_BOOT=1
+  -D RX2=5
+  -D TX2=17
+  -D ETH_PHY_TYPE=ETH_PHY_LAN8720
+  -D ETH_PHY_ADDR=1
+  -D ETH_PHY_MDC=23
+  -D ETH_PHY_MDIO=18
+  -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN
+  -D ETH_PHY_POWER=16


### PR DESCRIPTION
Added Support for wt32-eth01 board. Need to add a 1uF ceramic capacitor between pins EN and GND to avoid boot problems
![wt32-eth01 capacitor](https://github.com/jdgarcia99/openevse_esp32_firmware/assets/21177313/514478c0-4b93-4b30-be18-a7c02b242da3)
